### PR TITLE
Add functional variants of New(), Use(), and UseHandler()

### DIFF
--- a/negroni.go
+++ b/negroni.go
@@ -59,15 +59,6 @@ func New(handlers ...Handler) *Negroni {
 	}
 }
 
-// NewFromFuncs is similar to New(), but accepts a series of Negroni-style handler functions.
-func NewFromFuncs(handlerFuncs ...func(rw http.ResponseWriter, r *http.Request, next http.HandlerFunc)) *Negroni {
-	handlers := make([]Handler, len(handlerFuncs), len(handlerFuncs))
-	for i, f := range handlerFuncs {
-		handlers[i] = HandlerFunc(f)
-	}
-	return New(handlers...)
-}
-
 // Classic returns a new Negroni instance with the default middleware already
 // in the stack.
 //


### PR DESCRIPTION
At risk of cutting into Negroni's minimalism, here are some syntactic-sugar methods on the Negroni interface that ease the use of middleware expressed as functions rather than objects.

Prominent Golang HTTP libraries such as `net/http` and `gorilla/mux` seem to preserve an ambiguity between handlers as interfaces and handlers as functions. As a result, you tend to see variant methods such as `Handle()` and `HandleFunc()` that allow the use of handler functions without explicit casting.

You could argue that the reduction in casting verbosity even more useful in Negroni, since you are probably calling `Use()` multiple times to install different pieces of middleware.

You might even argue for a variadic version of `Use()`, but I'll leave that to a different conversation so as not to descend to quickly down a slippery slope.

##### `NewFromFuncs()`

Before:

```go
a := func(rw http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
	...
}

b := func(rw http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
	...
}

n := negroni.New(negroni.HandlerFunc(a), negroni.HandlerFunc(b))
```

After:

```go
a := func(rw http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
	...
}

b := func(rw http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
	...
}

n := negroni.NewFromFuncs(a, b)
```

##### `UseFunc()`

Before:

```go
n := negroni.New()
n.Use(negroni.HandlerFunc(func(rw http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
	...
}))
```

After:

```go
n := negroni.New()
n.UseFunc(func(rw http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
	...
})
```

##### `UseHandlerFunc()`

Before:

```go
n := negroni.New()
n.UseHandler(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
	...
}))
```

After:

```go
n := negroni.New()
n.UseHandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
	...
})
```

FYI: This is an attempt to resolve #67.