### PR TITLE
Make default Static middleware write a 404 status code when files are not found

### DIFF
--- a/static.go
+++ b/static.go
@@ -45,7 +45,8 @@ func (s *Static) ServeHTTP(rw http.ResponseWriter, r *http.Request, next http.Ha
 	}
 	f, err := s.Dir.Open(file)
 	if err != nil {
-		// discard the error?
+		// If the file wasn't found, write a 404 status code
+		rw.WriteHeader(http.StatusNotFound)
 		next(rw, r)
 		return
 	}


### PR DESCRIPTION
First, let me say I have been using negroni for several projects over the past year or so and have been absolutely loving it! I wanted to see if we could fix this small issue.

Judging by [the comment that ended with a question mark](https://github.com/codegangsta/negroni/blob/1dd3ab0ff59e13f5b73dcbf70703710aebe50d2f/static.go#L48) in the original source code, it looks like the decision to essentially ignore errors in the default Static middleware was made with at least some hesitation. I wanted to open it up for discussion.

I think that the Static middleware should write 404 errors to the response if a file is not found. Is there any reason why this should not be the case?

As is, the code I've written will continue to call the next middleware handler in the chain if a file is not found. This way, a user can decide for themselves what (if anything) to write in the body of the response. I'm not sure if this is the best way to do it. Here are some alternatives:

1. Write a generic message to the body (something like "Could not find foo/bar.html")  and then don't call the next middleware handler. The default Recovery middleware already writes to the body of the response when it recovers from panics, so this might be okay.
2. Write a response to the body and don't call the next middleware handler, but make it configurable. I was thinking something along the lines of what I did with [negroni-json-recovery](https://github.com/albrow/negroni-json-recovery#custom-response-formats).

What do you think?
