### PR TITLE
Add stats middleware to third party section in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,7 @@ Here is a current list of Negroni compatible middlware. Feel free to put up a PR
 | [cors](https://github.com/rs/cors) | [Olivier Poitrey](https://github.com/rs) | [Cross Origin Resource Sharing](http://www.w3.org/TR/cors/) (CORS) support |
 | [xrequestid](https://github.com/pilu/xrequestid) | [Andrea Franz](https://github.com/pilu) | Middleware that assigns a random X-Request-Id header to each request |
 | [VanGoH](https://github.com/auroratechnologies/vangoh) | [Taylor Wrobel](https://github.com/twrobel3) | Configurable [AWS-Style](http://docs.aws.amazon.com/AmazonS3/latest/dev/RESTAuthentication.html) HMAC authentication middleware |
+| [stats](https://github.com/thoas/stats) | [Florent Messa](https://github.com/thoas) | Store information about your web application (response time, etc.) |
 
 ## Examples
 [Alexander Rødseth](https://github.com/xyproto) created [mooseware](https://github.com/xyproto/mooseware), a skeleton for writing a Negroni middleware handler.


### PR DESCRIPTION
hi @codegangsta,

I have developed a dead simple middleware named [stats](https://github.com/thoas/stats) for both negroni and martini which stores various information of requests and responses:

* total response time
* average response time
* number of status code returned aggregated
* etc.

It's a simple PR to add it to negroni README.