### PR TITLE
Recover correctly after writing

### DIFF
--- a/recovery_test.go
+++ b/recovery_test.go
@@ -45,3 +45,23 @@ func TestRecovery(t *testing.T) {
 	refute(t, recorder.Body.Len(), 0)
 	refute(t, len(buff.String()), 0)
 }
+
+func TestRecoveryAfterWriting(t *testing.T) {
+	buff := bytes.NewBufferString("")
+	recorder := httptest.NewRecorder()
+
+	rec := NewRecovery()
+	rec.Logger = log.New(buff, "[negroni] ", 0)
+
+	n := New()
+	// replace log for testing
+	n.Use(rec)
+	n.UseHandler(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+		fmt.Fprint(res, "writing")
+		panic("here is a panic!")
+	}))
+	n.ServeHTTP(recorder, (*http.Request)(nil))
+	expect(t, recorder.Code, http.StatusInternalServerError)
+	refute(t, recorder.Body.Len(), 0)
+	refute(t, len(buff.String()), 0)
+}

--- a/recovery_test.go
+++ b/recovery_test.go
@@ -8,6 +8,25 @@ import (
 	"testing"
 )
 
+func TestNoRecovery(t *testing.T) {
+	buff := bytes.NewBufferString("")
+	recorder := httptest.NewRecorder()
+
+	rec := NewRecovery()
+	rec.Logger = log.New(buff, "[negroni] ", 0)
+
+	n := New()
+	// replace log for testing
+	n.Use(rec)
+	n.UseHandler(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+		fmt.Fprint(res, "writing")
+	}))
+	n.ServeHTTP(recorder, (*http.Request)(nil))
+	expect(t, recorder.Code, http.StatusOK)
+	refute(t, recorder.Body.Len(), 0)
+	expect(t, len(buff.String()), 0)
+}
+
 func TestRecovery(t *testing.T) {
 	buff := bytes.NewBufferString("")
 	recorder := httptest.NewRecorder()


### PR DESCRIPTION
The Recovery middleware couldn't recover a panic correctly after something was already written into the `ResponseWriter`. So I wrote some tests against this issue and fixed it.