### PR TITLE
Fix README route specific middleware section

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ adminRoutes := mux.NewRouter()
 // add admin routes here
 
 // Create a new negroni for the admin middleware
-router.Handle("/admin", negroni.New(
+router.PathPrefix("/admin").Handler(negroni.New(
   Middleware1,
   Middleware2,
   negroni.Wrap(adminRoutes),


### PR DESCRIPTION
Update the README to reflect the new way mux handles path prefix routing.