### PR TITLE
Add convenience func to wrap *log.Logger with *negroni.Logger

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -18,6 +18,11 @@ func NewLogger() *Logger {
 	return &Logger{log.New(os.Stdout, "[negroni] ", 0)}
 }
 
+// NewWithLogger returns a new Logger instance using the given *log.Logger
+func NewWithLogger(logger *log.Logger) *Logger {
+	return &Logger{logger}
+}
+
 func (l *Logger) ServeHTTP(rw http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
 	start := time.Now()
 	l.Printf("Started %s %s", r.Method, r.URL.Path)

--- a/logger_test.go
+++ b/logger_test.go
@@ -31,3 +31,27 @@ func Test_Logger(t *testing.T) {
 	expect(t, recorder.Code, http.StatusNotFound)
 	refute(t, len(buff.String()), 0)
 }
+
+func Test_With_Logger(t *testing.T) {
+	buff := bytes.NewBufferString("")
+	recorder := httptest.NewRecorder()
+
+	applog := log.New(buff, "[negroni] ", 0)
+	l := NewWithLogger(applog)
+
+	n := New()
+	// replace log for testing
+	n.Use(l)
+	n.UseHandler(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+		rw.WriteHeader(http.StatusNotFound)
+	}))
+
+	req, err := http.NewRequest("GET", "http://localhost:3000/foobar", nil)
+	if err != nil {
+		t.Error(err)
+	}
+
+	n.ServeHTTP(recorder, req)
+	expect(t, recorder.Code, http.StatusNotFound)
+	refute(t, len(buff.String()), 0)
+}


### PR DESCRIPTION
A suggestion to allow overriding the logger directly.

I think this reads better than replacing the .Logger in the Logger middleware.