### PR TITLE
Write default content type during panic recovery

### DIFF
--- a/recovery.go
+++ b/recovery.go
@@ -29,6 +29,7 @@ func NewRecovery() *Recovery {
 func (rec *Recovery) ServeHTTP(rw http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
 	defer func() {
 		if err := recover(); err != nil {
+			rw.Header().Set("Content-Type", "text/plain; charset=utf-8")
 			rw.WriteHeader(http.StatusInternalServerError)
 			stack := make([]byte, rec.StackSize)
 			stack = stack[:runtime.Stack(stack, rec.StackAll)]


### PR DESCRIPTION
This is for compatibility with Negroni Gzip (which sets its own content type if not explicitly sent by the user), so I don't get a gzip download on a panic :)