### PR TITLE
Update README URLs based on HTTP redirects

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Negroni is an idiomatic approach to web middleware in Go. It is tiny, non-intrusive, and encourages use of `net/http` Handlers.
 
-If you like the idea of [Martini](http://github.com/go-martini/martini), but you think it contains too much magic, then Negroni is a great fit.
+If you like the idea of [Martini](https://github.com/go-martini/martini), but you think it contains too much magic, then Negroni is a great fit.
 
 
 Language Translations:
@@ -52,7 +52,7 @@ If you have a question or feature request, [go ask the mailing list](https://gro
 Negroni is **not** a framework. It is a library that is designed to work directly with net/http.
 
 ## Routing?
-Negroni is BYOR (Bring your own Router). The Go community already has a number of great http routers available, Negroni tries to play well with all of them by fully supporting `net/http`. For instance, integrating with [Gorilla Mux](http://github.com/gorilla/mux) looks like so:
+Negroni is BYOR (Bring your own Router). The Go community already has a number of great http routers available, Negroni tries to play well with all of them by fully supporting `net/http`. For instance, integrating with [Gorilla Mux](https://github.com/gorilla/mux) looks like so:
 
 ~~~ go
 router := mux.NewRouter()
@@ -148,7 +148,7 @@ Here is a current list of Negroni compatible middlware. Feel free to put up a PR
 | Middleware | Author | Description |
 | -----------|--------|-------------|
 | [RestGate](https://github.com/pjebs/restgate) | [Prasanga Siripala](https://github.com/pjebs) | Secure authentication for REST API endpoints |
-| [Graceful](https://github.com/stretchr/graceful) | [Tyler Bunnell](https://github.com/tylerb) | Graceful HTTP Shutdown |
+| [Graceful](https://github.com/tylerb/graceful) | [Tyler Bunnell](https://github.com/tylerb) | Graceful HTTP Shutdown |
 | [secure](https://github.com/unrolled/secure) | [Cory Jacobsen](https://github.com/unrolled) | Middleware that implements a few quick security wins |
 | [JWT Middleware](https://github.com/auth0/go-jwt-middleware) | [Auth0](https://github.com/auth0) | Middleware checks for a JWT on the `Authorization` header on incoming requests and decodes it|
 | [binding](https://github.com/mholt/binding) | [Matt Holt](https://github.com/mholt) | Data binding from HTTP requests into structs |
@@ -174,8 +174,8 @@ Here is a current list of Negroni compatible middlware. Feel free to put up a PR
 ## Essential Reading for Beginners of Go & Negroni
 
 * [Using a Context to pass information from middleware to end handler](http://elithrar.github.io/article/map-string-interface/)
-* [Understanding middleware](http://mattstauffer.co/blog/laravel-5.0-middleware-replacing-filters)
+* [Understanding middleware](https://mattstauffer.co/blog/laravel-5.0-middleware-filter-style)
 
 ## About
 
-Negroni is obsessively designed by none other than the [Code Gangsta](http://codegangsta.io/)
+Negroni is obsessively designed by none other than the [Code Gangsta](https://codegangsta.io/)


### PR DESCRIPTION
Created with https://github.com/dkhamsing/frankenstein

### GitHub Corrected URLs 
Was | Now 
--- | --- 
http://github.com/go-martini/martini | https://github.com/go-martini/martini 
http://github.com/gorilla/mux | https://github.com/gorilla/mux 
https://github.com/stretchr/graceful | https://github.com/tylerb/graceful 


### Other Corrected URLs 
Was | Now 
--- | --- 
http://codegangsta.io/ | https://codegangsta.io/ 
http://mattstauffer.co/blog/laravel-5.0-middleware-replacing-filters | https://mattstauffer.co/blog/laravel-5.0-middleware-filter-style 
