### PR TITLE
Add ErrorHandler interface to Recovery

### DIFF
--- a/recovery.go
+++ b/recovery.go
@@ -27,18 +27,6 @@ func NewRecovery() *Recovery {
 	}
 }
 
-// NewRecoveryWithFunc returns a nwe instance of Recovery with an
-// attached errorHandlerFunction
-func NewRecoveryWithFunc(errorHandlerFunc func(interface{})) *Recovery {
-	return &Recovery{
-		Logger:           log.New(os.Stdout, "[negroni] ", 0),
-		PrintStack:       true,
-		ErrorHandlerFunc: errorHandlerFunc,
-		StackAll:         false,
-		StackSize:        1024 * 8,
-	}
-}
-
 func (rec *Recovery) ServeHTTP(rw http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
 	defer func() {
 		if err := recover(); err != nil {

--- a/recovery.go
+++ b/recovery.go
@@ -8,10 +8,15 @@ import (
 	"runtime/debug"
 )
 
+type ErrorHandlerFunc interface {
+	Handle(err interface{}, report bool)
+}
+
 // Recovery is a Negroni middleware that recovers from any panics and writes a 500 if there was one.
 type Recovery struct {
-	Logger     *log.Logger
-	PrintStack bool
+	Logger           *log.Logger
+	PrintStack       bool
+	ErrorHandlerFunc ErrorHandlerFunc
 }
 
 // NewRecovery returns a new instance of Recovery
@@ -32,6 +37,10 @@ func (rec *Recovery) ServeHTTP(rw http.ResponseWriter, r *http.Request, next htt
 
 			if rec.PrintStack {
 				fmt.Fprintf(rw, f, err, stack)
+			}
+
+			if rec.ErrorHandlerFunc != nil {
+				rec.ErrorHandlerFunc.Handle(err, true)
 			}
 		}
 	}()

--- a/recovery.go
+++ b/recovery.go
@@ -8,15 +8,11 @@ import (
 	"runtime"
 )
 
-type ErrorHandlerFunc interface {
-	HandleError(err interface{}, report bool)
-}
-
 // Recovery is a Negroni middleware that recovers from any panics and writes a 500 if there was one.
 type Recovery struct {
 	Logger           *log.Logger
 	PrintStack       bool
-	ErrorHandlerFunc ErrorHandlerFunc
+	ErrorHandlerFunc func(interface{})
 	StackAll         bool
 	StackSize        int
 }
@@ -33,7 +29,7 @@ func NewRecovery() *Recovery {
 
 // NewRecoveryWithFunc returns a nwe instance of Recovery with an
 // attached errorHandlerFunction
-func NewRecoveryWithFunc(errorHandlerFunc ErrorHandlerFunc) *Recovery {
+func NewRecoveryWithFunc(errorHandlerFunc func(interface{})) *Recovery {
 	return &Recovery{
 		Logger:           log.New(os.Stdout, "[negroni] ", 0),
 		PrintStack:       true,
@@ -58,7 +54,7 @@ func (rec *Recovery) ServeHTTP(rw http.ResponseWriter, r *http.Request, next htt
 			}
 
 			if rec.ErrorHandlerFunc != nil {
-				rec.ErrorHandlerFunc.HandleError(err, true)
+				rec.ErrorHandlerFunc(err)
 			}
 		}
 	}()

--- a/recovery.go
+++ b/recovery.go
@@ -27,6 +27,16 @@ func NewRecovery() *Recovery {
 	}
 }
 
+// NewRecoveryWithFunc returns a nwe instance of Recovery with an
+// attached errorHandlerFunction
+func NewRecoveryWithFunc(errorHandlerFunc ErrorHandlerFunc) *Recovery {
+	return &Recovery{
+		Logger:           log.New(os.Stdout, "[negroni] ", 0),
+		PrintStack:       true,
+		ErrorHandlerFunc: errorHandlerFunc,
+	}
+}
+
 func (rec *Recovery) ServeHTTP(rw http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
 	defer func() {
 		if err := recover(); err != nil {

--- a/recovery.go
+++ b/recovery.go
@@ -9,7 +9,7 @@ import (
 )
 
 type ErrorHandlerFunc interface {
-	Handle(err interface{}, report bool)
+	HandleError(err interface{}, report bool)
 }
 
 // Recovery is a Negroni middleware that recovers from any panics and writes a 500 if there was one.
@@ -50,7 +50,7 @@ func (rec *Recovery) ServeHTTP(rw http.ResponseWriter, r *http.Request, next htt
 			}
 
 			if rec.ErrorHandlerFunc != nil {
-				rec.ErrorHandlerFunc.Handle(err, true)
+				rec.ErrorHandlerFunc.HandleError(err, true)
 			}
 		}
 	}()

--- a/recovery.go
+++ b/recovery.go
@@ -38,6 +38,8 @@ func NewRecoveryWithFunc(errorHandlerFunc ErrorHandlerFunc) *Recovery {
 		Logger:           log.New(os.Stdout, "[negroni] ", 0),
 		PrintStack:       true,
 		ErrorHandlerFunc: errorHandlerFunc,
+		StackAll:         false,
+		StackSize:        1024 * 8,
 	}
 }
 


### PR DESCRIPTION
I'm not really sure if these changes are desired, but I needed a way to attach an error reporting service up to recovery so I added this. 

It allows for a simple mechanism to hook up Sentry/Airbrake/New Relic error reporting on unhandled panics. If there is any interest in merging this in, I'll write up some code comments and some documentation. 