### PR TITLE
Add gorilla mux subrouting middleware example

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,22 @@ router.Handle("/admin", negroni.New(
 ))
 ~~~
 
+If you are using [gorilla/mux](http://www.gorillatoolkit.org/pkg/mux) here is an example using a subrouter.
+
+~~~go
+router := mux.NewRouter()
+subRouter := mux.NewRouter().PathPrefix("/subpath").Subrouter().StrictSlash(true)
+subRouter.HandleFunc("/", someSubpathHandler) // "/subpath/"
+subRouter.HandleFunc("/:id", someSubpathHandler) // "/subpath/:id"
+
+// "/subpath" is necessary to ensure the subRouter and main router linkup
+router.PathPrefix("/subpath").Handler(negroni.New(
+	Middleware1,
+	Middleware2,
+	negroni.Wrap(subRouter),
+))
+~~~
+
 ## Third Party Middleware
 
 Here is a current list of Negroni compatible middlware. Feel free to put up a PR linking your middleware if you have built one:


### PR DESCRIPTION
I was having a bit of trouble getting gorilla/mux to do the subroutes with middleware like I wanted. 

This stackoverflow post really helped me out: http://stackoverflow.com/a/30538020/1686511

I wanted to add the example to the readme so it can help others out in the future. 