### PR TITLE
Set Content-Type in Recovery handler

### DIFF
--- a/recovery.go
+++ b/recovery.go
@@ -29,6 +29,10 @@ func NewRecovery() *Recovery {
 func (rec *Recovery) ServeHTTP(rw http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
 	defer func() {
 		if err := recover(); err != nil {
+			if rw.Header().Get("Content-Type") == "" {
+				rw.Header().Set("Content-Type", "text/plain; charset=utf-8")
+			}
+
 			rw.WriteHeader(http.StatusInternalServerError)
 			stack := make([]byte, rec.StackSize)
 			stack = stack[:runtime.Stack(stack, rec.StackAll)]

--- a/recovery_test.go
+++ b/recovery_test.go
@@ -22,7 +22,24 @@ func TestRecovery(t *testing.T) {
 		panic("here is a panic!")
 	}))
 	n.ServeHTTP(recorder, (*http.Request)(nil))
+	expect(t, recorder.Header().Get("Content-Type"), "text/plain; charset=utf-8")
 	expect(t, recorder.Code, http.StatusInternalServerError)
 	refute(t, recorder.Body.Len(), 0)
 	refute(t, len(buff.String()), 0)
+}
+
+func TestRecovery_noContentTypeOverwrite(t *testing.T) {
+	recorder := httptest.NewRecorder()
+
+	rec := NewRecovery()
+	rec.Logger = log.New(bytes.NewBuffer([]byte{}), "[negroni] ", 0)
+
+	n := New()
+	n.Use(rec)
+	n.UseHandler(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+		res.Header().Set("Content-Type", "application/javascript; charset=utf-8")
+		panic("here is a panic!")
+	}))
+	n.ServeHTTP(recorder, (*http.Request)(nil))
+	expect(t, recorder.Header().Get("Content-Type"), "application/javascript; charset=utf-8")
 }


### PR DESCRIPTION
If a panic occurs and there is no content-type yet

Continues work from @Anon-Penguin in #98