### PR TITLE
Fix Written() return value

### DIFF
--- a/response_writer_test.go
+++ b/response_writer_test.go
@@ -46,6 +46,14 @@ func (h *hijackableResponse) Hijack() (net.Conn, *bufio.ReadWriter, error) {
 	return nil, nil, nil
 }
 
+func TestResponseWriterBeforeWrite(t *testing.T) {
+	rec := httptest.NewRecorder()
+	rw := NewResponseWriter(rec)
+
+	expect(t, rw.Status(), http.StatusOK)
+	expect(t, rw.Written(), false)
+}
+
 func TestResponseWriterWritingString(t *testing.T) {
 	rec := httptest.NewRecorder()
 	rw := NewResponseWriter(rec)


### PR DESCRIPTION
34a385a361d169adb4b036c1b35fa38305dc2b47 defaulted the response code to
200, but this causes Written() to always return true, even if it hasn't
been written to yet.

cc/ @alesstimec @alecha can you describe your use case a bit more for the functionality introduced in #101 ? It feels like returning 0 if the response hasn't yet been written is a more accurate representation of the state of the request so I'm curious what motivated the change (this PR maintains that behavior).